### PR TITLE
feat: add marketing campaigns support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 helix-importer-ui
+ued.js

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -433,6 +433,25 @@ export async function runCampaign(customOptions) {
     return null;
   }
 
+  const forcedAudience = usp.has(options.audiencesQueryParameter)
+    ? toClassName(usp.get(options.audiencesQueryParameter))
+    : null;
+  const audiences = getMetadata('campaign-audience').split(',').map(toClassName);
+
+  if (forcedAudience && !audiences.includes(forcedAudience)) {
+    return null;
+  }
+
+  if (audiences.length) {
+    const resolvedAudiences = await getResolvedAudiences(
+      audiences,
+      options.audiences,
+    );
+    if (!resolvedAudiences.length) {
+      return false;
+    }
+  }
+
   const allowedCampaigns = getAllMetadata(options.campaignsMetaTagPrefix);
   if (!Object.keys(allowedCampaigns).includes(campaign)) {
     return null;

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -51,7 +51,7 @@ function isBot() {
  * @param {object} allAudiences object defining all available audiences and their resolution logic
  * @returns Returns the names of the resolved audiences
  */
-async function getResolvedAudiences(configured = [], allAudiences = {}) {
+export async function getResolvedAudiences(configured = [], allAudiences = {}) {
   const results = await Promise.all(
     configured
       .map((key) => {
@@ -442,7 +442,7 @@ export async function runCampaign(customOptions) {
     return null;
   }
 
-  if (audiences.length) {
+  if (!forcedAudience && audiences.length) {
     const resolvedAudiences = await getResolvedAudiences(
       audiences,
       options.audiences,

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -15,6 +15,7 @@ import {
   toCamelCase,
   toClassName,
 } from '../lib-franklin.js';
+// eslint-disable-next-line import/no-cycle
 import { getAllMetadata } from '../scripts.js';
 
 export const DEFAULT_OPTIONS = {
@@ -391,6 +392,7 @@ export async function runCampaign() {
     const url = new URL(urlString);
     return replaceInner(url.pathname, document.querySelector('main'));
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error(err);
     return null;
   }
@@ -466,6 +468,6 @@ export async function loadLazy(customOptions = {}) {
     ...DEFAULT_OPTIONS,
     ...customOptions,
   };
-  const preview = await import(`./preview.js`);
+  const preview = await import('./preview.js');
   preview.default(options);
 }

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -28,7 +28,7 @@ export const DEFAULT_OPTIONS = {
 
   // Campaigns related properties
   campaignsMetaTagPrefix: 'campaign',
-  campaignsQueryParameter: 'campaign',
+  campaignsQueryParameter: 'campaign', // TODO: also support `utm_campaign`
 
   // Experimentation related properties
   experimentsRoot: '/experiments',
@@ -442,9 +442,10 @@ export async function runCampaign(customOptions) {
 
   const options = { ...DEFAULT_OPTIONS, ...customOptions };
   const usp = new URLSearchParams(window.location.search);
-  const campaign = usp.has(options.campaignsQueryParameter)
+  const campaign = (usp.has(options.campaignsQueryParameter)
     ? toClassName(usp.get(options.campaignsQueryParameter))
-    : null;
+    : null)
+    || (usp.has('utm_campaign') ? toClassName(usp.get('utm_campaign')) : null);
   if (!campaign) {
     return null;
   }

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -19,10 +19,12 @@ import {
 import { getAllMetadata } from '../scripts.js';
 
 export const DEFAULT_OPTIONS = {
-  root: '/experiments',
-  configFile: 'manifest.json',
-  metaTag: 'experiment',
-  queryParameter: 'experiment',
+  campaignsMetaTagPrefix: 'campaign',
+  campaignsQueryParameter: 'campaign',
+  experimentsRoot: '/experiments',
+  experimentsConfigFile: 'manifest.json',
+  experimentsMetaTag: 'experiment',
+  experimentsQueryParameter: 'experiment',
 };
 
 /**
@@ -182,7 +184,7 @@ export function getConfigForInstantExperiment(experimentId, instantExperiment) {
  * @returns {object} containing the experiment manifest
  */
 export async function getConfigForFullExperiment(experimentId, cfg) {
-  const path = `${cfg.root}/${experimentId}/${cfg.configFile}`;
+  const path = `${cfg.experimentsRoot}/${experimentId}/${cfg.experimentsConfigFile}`;
   try {
     const resp = await fetch(path);
     if (!resp.ok) {
@@ -199,7 +201,7 @@ export async function getConfigForFullExperiment(experimentId, cfg) {
     }
     config.id = experimentId;
     config.manifest = path;
-    config.basePath = `${cfg.root}/${experimentId}`;
+    config.basePath = `${cfg.experimentsRoot}/${experimentId}`;
     return config;
   } catch (e) {
     // eslint-disable-next-line no-console
@@ -316,7 +318,7 @@ export async function runExperiment(customOptions = {}) {
   }
 
   const options = { ...DEFAULT_OPTIONS, ...customOptions };
-  const experiment = getMetadata('experiment');
+  const experiment = getMetadata(options.experimentsMetaTag);
   if (!experiment) {
     return false;
   }
@@ -367,18 +369,21 @@ export async function runExperiment(customOptions = {}) {
   return result;
 }
 
-export async function runCampaign() {
+export async function runCampaign(customOptions) {
   if (isBot()) {
     return null;
   }
 
+  const options = { ...DEFAULT_OPTIONS, ...customOptions };
   const usp = new URLSearchParams(window.location.search);
-  const campaign = usp.has('campaign') ? toClassName(usp.get('campaign')) : null;
+  const campaign = usp.has(options.campaignsQueryParameter)
+    ? toClassName(usp.get(options.campaignsQueryParameter))
+    : null;
   if (!campaign) {
     return null;
   }
 
-  const allowedCampaigns = getAllMetadata('campaign');
+  const allowedCampaigns = getAllMetadata(options.campaignsMetaTagPrefix);
   if (!Object.keys(allowedCampaigns).includes(campaign)) {
     return null;
   }

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -23,12 +23,13 @@ export const DEFAULT_OPTIONS = {
   rumSamplingRate: 10, // 1 in 10 requests
 
   // Audiences related properties
+  audiences: {},
   audiencesMetaTagPrefix: 'audience',
   audiencesQueryParameter: 'audience',
 
   // Campaigns related properties
   campaignsMetaTagPrefix: 'campaign',
-  campaignsQueryParameter: 'campaign', // TODO: also support `utm_campaign`
+  campaignsQueryParameter: 'campaign',
 
   // Experimentation related properties
   experimentsRoot: '/experiments',

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -617,6 +617,7 @@ export async function loadLazy(customOptions = {}) {
     ...DEFAULT_OPTIONS,
     ...customOptions,
   };
+  // eslint-disable-next-line import/no-cycle
   const preview = await import('./preview.js');
   preview.default(pluginOptions);
 }

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -250,6 +250,21 @@ function getDecisionPolicy(config) {
 }
 
 /**
+ * this is an extensible stub to take on audience mappings
+ * @param {string} audience
+ * @return {boolean} is member of this audience
+ */
+function isValidAudience(audience) {
+  if (audience === 'mobile') {
+    return window.innerWidth < 600;
+  }
+  if (audience === 'desktop') {
+    return window.innerWidth >= 600;
+  }
+  return true;
+}
+
+/**
  * Replaces element with content from path
  * @param {string} path
  * @param {HTMLElement} element
@@ -317,7 +332,7 @@ export async function runExperiment(customOptions = {}) {
   }
 
   const pluginOptions = { ...DEFAULT_OPTIONS, ...customOptions };
-  const experiment = getMetadata(options.experimentsMetaTag);
+  const experiment = getMetadata(pluginOptions.experimentsMetaTag);
   if (!experiment) {
     return false;
   }
@@ -472,7 +487,7 @@ function adjustedRumSamplingRate(customOptions) {
     sampleRUM.drain('stash', sampleRUM);
     sendPing(data);
     return true;
-  }
+  };
 }
 
 export async function loadEager(customOptions = {}) {

--- a/scripts/experience-decisioning/preview.js
+++ b/scripts/experience-decisioning/preview.js
@@ -266,9 +266,10 @@ async function decorateCampaignPill(overlay, options) {
   const audiences = campaigns.audience.split(',').map(toClassName);
   const resolvedAudiences = await getResolvedAudiences(audiences, options);
   const isActive = forcedAudience ? audiences.includes(forcedAudience) : !!resolvedAudiences.length;
-  const campaign = usp.has(options.campaignsQueryParameter)
+  const campaign = (usp.has(options.campaignsQueryParameter)
     ? toClassName(usp.get(options.campaignsQueryParameter))
-    : null;
+    : null)
+    || (usp.has('utm_campaign') ? toClassName(usp.get('utm_campaign')) : null);
   const pill = createPopupButton(
     `Campaign: ${campaign || 'default'}`,
     {

--- a/scripts/experience-decisioning/preview.js
+++ b/scripts/experience-decisioning/preview.js
@@ -217,7 +217,12 @@ async function decorateExperimentPill(overlay, options) {
       label: config.label,
       description: `
         <div class="hlx-details">
-          ${config.status}${config.resolvedAudiences ? ', ' : ''}${config.resolvedAudiences.length ? config.resolvedAudiences[0] : 'No audience resolved'}${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}${config.variants[config.variantNames[0]].blocks.join(',')}
+          ${config.status}
+          ${config.resolvedAudiences ? ', ' : ''}
+          ${config.resolvedAudiences && config.resolvedAudiences.length ? config.resolvedAudiences[0] : ''}
+          ${config.resolvedAudiences && !config.resolvedAudiences.length ? 'No audience resolved' : ''}
+          ${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}
+          ${config.variants[config.variantNames[0]].blocks.join(',')}
         </div>
         <div class="hlx-info">How is it going?</div>`,
       actions: config.manifest ? [{ label: 'Manifest', href: config.manifest }] : [],
@@ -265,7 +270,9 @@ async function decorateCampaignPill(overlay, options) {
     : null;
   const audiences = campaigns.audience.split(',').map(toClassName);
   const resolvedAudiences = await getResolvedAudiences(audiences, options);
-  const isActive = forcedAudience ? audiences.includes(forcedAudience) : !!resolvedAudiences.length;
+  const isActive = forcedAudience
+    ? audiences.includes(forcedAudience)
+    : (!resolvedAudiences || !!resolvedAudiences.length);
   const campaign = (usp.has(options.campaignsQueryParameter)
     ? toClassName(usp.get(options.campaignsQueryParameter))
     : null)
@@ -312,7 +319,7 @@ function createAudience(audience, isSelected, options) {
  */
 async function decorateAudiencesPill(overlay, options) {
   const audiences = getAllMetadata(options.audiencesMetaTagPrefix);
-  if (!Object.keys(audiences).length) {
+  if (!Object.keys(audiences).length || !Object.keys(options.audiences).length) {
     return;
   }
 
@@ -348,7 +355,7 @@ export default async function decoratePreviewMode(options) {
     const overlay = getOverlay();
     await decorateAudiencesPill(overlay, options);
     await decorateCampaignPill(overlay, options);
-    await decorateExperimentPill(overlay);
+    await decorateExperimentPill(overlay, options);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(e);

--- a/scripts/experience-decisioning/preview.js
+++ b/scripts/experience-decisioning/preview.js
@@ -268,7 +268,9 @@ async function decorateCampaignPill(overlay) {
       ...Object.keys(campaigns).map((c) => createCampaign(c, toClassName(campaign) === c)),
     ],
   );
-  pill.classList.add(`is-${toClassName(campaign ? 'active' : 'inactive')}`);
+  if (campaign) {
+    pill.classList.add('is-active');
+  }
   overlay.append(pill);
 }
 

--- a/scripts/experience-decisioning/preview.js
+++ b/scripts/experience-decisioning/preview.js
@@ -7,6 +7,7 @@ import {
   createPopupButton,
   getOverlay,
 } from '../../tools/preview/preview.js';
+// eslint-disable-next-line import/no-cycle
 import { getAllMetadata } from '../scripts.js';
 /*
  * Copyright 2022 Adobe. All rights reserved.

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -42,7 +42,7 @@ const plugins = {
     },
   },
   experienceDecisioning: {
-    condition: () => !!getMetadata('experiment') || Object.keys(getAllMetadata('campaign')).length,
+    condition: () => getMetadata('experiment') || Object.keys(getAllMetadata('campaign')).length,
     loadEager: async () => {
       // eslint-disable-next-line import/no-cycle
       const { loadEager: runEager } = await import('./experience-decisioning/index.js');


### PR DESCRIPTION
# Use case

As a marketer, I want to be able to send emails with custom links that serve specific content variations.

# Authoring

This PR adds support for creating page variations for marketing campaigns. This is done similarly to the experimentation engine and builds on top of it.

Metadata entries are added to the main entry page for each campaign we want to support. The format is as given below:

<img width="642" alt="Screenshot 2023-08-11 at 9 53 26 AM" src="https://github.com/ramboz/franklin-experience-decisioning/assets/1235810/a78331d5-117d-49b6-9a7f-7994f0c63439">

Alternative notations like `Campaign: Test3` or `Campaign Test4` are also supported.

When campaigns are defined for a page, you can trigger the variations by using the `campaign` query parameter, as shown in the test URLs at the bottom, or the industry best-practice `utm_campaign` one.

It is also possible to restrict campaigns to specific audiences by adding a `Campaign Audience` page metadata attribute with the name of the audience.

A page that has campaigns running will also show an overlay pill, similar to experimentation use cases:
<img width="326" alt="Screenshot 2023-08-11 at 10 04 26 AM" src="https://github.com/ramboz/franklin-experience-decisioning/assets/1235810/0b1baa2c-d81f-45d1-b713-5cdf219368a5">

The pill lets you easily switch between variations so you can preview what the end user will ultimately see.

Test URLs:
- Before: https://main--franklin-experience-decisioning--ramboz.hlx.page/
- After:
  - https://campaigns--franklin-experience-decisioning--ramboz.hlx.page/campaigns/campaign-demo
  - https://campaigns--franklin-experience-decisioning--ramboz.hlx.page/campaigns/campaign-demo?campaign=Test1
  - https://campaigns--franklin-experience-decisioning--ramboz.hlx.page/campaigns/campaign-demo?campaign=Test2