### PR TITLE
feat: add support for custom audiences

### DIFF
--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -51,7 +51,7 @@ async function getResolvedAudiences(configured, allAudiences) {
         return false;
       }),
   );
-  return Object.keys(allAudiences).filter((_, i) => results[i]);
+  return configured.filter((_, i) => results[i]);
 }
 
 /**
@@ -107,7 +107,7 @@ function parseExperimentConfig(json) {
     json.settings.data.forEach((line) => {
       const key = toCamelCase(line.Name);
       if (key === 'audience') {
-        config.audiences = line.Value;
+        config.audiences = [line.Value];
       } else {
         config[key] = line.Value;
       }
@@ -152,7 +152,7 @@ function parseExperimentConfig(json) {
  * @param {object} config the config to check
  * @returns `true` if it is valid, `false` otherwise
  */
-export function isExperimentValidConfig(config) {
+export function isValidExperimentationConfig(config) {
   if (!config.variantNames
     || !config.variantNames.length
     || !config.variants
@@ -343,7 +343,7 @@ export async function runExperiment(customOptions = {}) {
     // eslint-disable-next-line no-console
     console.error('Invalid experiment config.', err);
   }
-  if (!experimentConfig || !isExperimentValidConfig(experimentConfig)) {
+  if (!experimentConfig || !isValidExperimentationConfig(experimentConfig)) {
     // eslint-disable-next-line no-console
     console.warn('Invalid experiment config. Please review your metadata, sheet and parser.');
     return false;

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -15,6 +15,7 @@ import {
   toCamelCase,
   toClassName,
 } from '../lib-franklin.js';
+// eslint-disable-next-line import/no-cycle
 import { getAllMetadata } from '../scripts.js';
 
 export const DEFAULT_OPTIONS = {
@@ -483,6 +484,6 @@ export async function loadLazy(customOptions = {}) {
     ...DEFAULT_OPTIONS,
     ...customOptions,
   };
-  const preview = await import(`./preview.js`);
+  const preview = await import('./preview.js');
   preview.default(options);
 }

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -327,9 +327,13 @@ export async function getConfig(experiment, instantExperiment, pluginOptions) {
     return null;
   }
 
+  experimentConfig.resolvedAudiences = await getResolvedAudiences(
+    experimentConfig.audiences,
+    pluginOptions.audiences,
+  );
   experimentConfig.run = !!forcedExperiment
     || !experimentConfig.audiences.length
-    || !!(await getResolvedAudiences(experimentConfig.audiences, pluginOptions.audiences)).length;
+    || !!(experimentConfig.resolvedAudiences).length;
   if (!experimentConfig.run) {
     return null;
   }

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -87,7 +87,6 @@ async function replaceInner(path, element) {
  *      {
  *        id: <string>,
  *        label: <string>,
- *        blocks: [<string>]
  *        audiences: [<string>],
  *        status: Active | Inactive,
  *        variantNames: [<string>],
@@ -106,8 +105,8 @@ function parseExperimentConfig(json) {
   try {
     json.settings.data.forEach((line) => {
       const key = toCamelCase(line.Name);
-      if (key === 'audience') {
-        config.audiences = [line.Value];
+      if (key === 'audience' || key === 'audiences') {
+        config.audiences = line.Value.join(',');
       } else {
         config[key] = line.Value;
       }

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -413,7 +413,7 @@ export async function serveAudience(customOptions) {
     }
     sampleRUM('audiences', {
       source: window.location.href,
-      target: forcedAudience || audiences.join(','),
+      target: result ? forcedAudience || audiences.join(',') : 'default',
     });
     return result;
   } catch (err) {

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -520,7 +520,7 @@ function adjustedRumSamplingRate(customOptions) {
     sampleRUM.drain('stash', sampleRUM);
     sendPing(data);
     return true;
-  }
+  };
 }
 
 export async function loadEager(customOptions = {}) {

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -41,7 +41,7 @@ function isBot() {
  * @param {object} allAudiences object defining all available audiences and their resolution logic
  * @returns Returns the names of the resolved audiences
  */
-async function getResolvedAudiences(configured, allAudiences) {
+async function getResolvedAudiences(configured = [], allAudiences = {}) {
   const results = await Promise.all(
     configured
       .map((key) => {
@@ -87,6 +87,7 @@ async function replaceInner(path, element) {
  *      {
  *        id: <string>,
  *        label: <string>,
+ *        blocks: <string>,
  *        audiences: [<string>],
  *        status: Active | Inactive,
  *        variantNames: [<string>],
@@ -147,7 +148,7 @@ function parseExperimentConfig(json) {
 }
 
 /**
- * Checs if the given config is a valid experimentation configuration.
+ * Checks if the given config is a valid experimentation configuration.
  * @param {object} config the config to check
  * @returns `true` if it is valid, `false` otherwise
  */
@@ -304,6 +305,7 @@ export async function getConfig(experiment, instantExperiment, config) {
   }
 
   experimentConfig.run = !!forcedExperiment
+    || !experimentConfig.audiences.length
     || !!(await getResolvedAudiences(experimentConfig.audiences, config.audiences)).length;
   if (!experimentConfig.run) {
     return null;

--- a/scripts/experience-decisioning/index.js
+++ b/scripts/experience-decisioning/index.js
@@ -406,7 +406,16 @@ export async function serveAudience(customOptions) {
 
   try {
     const url = new URL(urlString);
-    return replaceInner(url.pathname, document.querySelector('main'));
+    const result = replaceInner(url.pathname, document.querySelector('main'));
+    if (!result) {
+      // eslint-disable-next-line no-console
+      console.debug(`failed to serve audience ${forcedAudience || audiences[0]}. Falling back to default content.`);
+    }
+    sampleRUM('audiences', {
+      source: window.location.href,
+      target: forcedAudience || audiences.join(','),
+    });
+    return result;
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(err);

--- a/scripts/experience-decisioning/preview.js
+++ b/scripts/experience-decisioning/preview.js
@@ -214,7 +214,7 @@ async function decorateExperimentPill(overlay) {
       label: config.label,
       description: `
         <div class="hlx-details">
-          ${config.status}${config.audience ? ', ' : ''}${config.audience}${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}${config.variants[config.variantNames[0]].blocks.join(',')}
+          ${config.status}${config.audiences.length ? ', ' : ''}${config.audiences[0]}${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}${config.variants[config.variantNames[0]].blocks.join(',')}
         </div>
         <div class="hlx-info">How is it going?</div>`,
       actions: config.manifest ? [{ label: 'Manifest', href: config.manifest }] : [],

--- a/scripts/experience-decisioning/preview.js
+++ b/scripts/experience-decisioning/preview.js
@@ -213,7 +213,7 @@ async function decorateExperimentPill(overlay) {
       label: config.label,
       description: `
         <div class="hlx-details">
-          ${config.status}${config.audiences.length ? ', ' : ''}${config.audiences[0]}${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}${config.variants[config.variantNames[0]].blocks.join(',')}
+          ${config.status}${config.resolvedAudiences.length ? ', ' : ''}${config.resolvedAudiences[0]}${config.variants[config.variantNames[0]].blocks.length ? ', Blocks: ' : ''}${config.variants[config.variantNames[0]].blocks.join(',')}
         </div>
         <div class="hlx-info">How is it going?</div>`,
       actions: config.manifest ? [{ label: 'Manifest', href: config.manifest }] : [],

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -20,9 +20,6 @@ const LCP_BLOCKS = []; // add your LCP blocks to the list
 const audiences = {
   mobile: () => window.innerWidth < 600,
   desktop: () => window.innerWidth >= 600,
-  customer: () => document.cookie.split('; ')
-    .find((entry) => entry.startsWith('is-customer='))
-    ?.split('=')[1] || false,
 };
 
 /**
@@ -43,7 +40,8 @@ export function getAllMetadata(scope) {
 
 const plugins = {
   preview: {
-    condition: () => window.location.hostname.endsWith('hlx.page') || window.location.hostname === ('localhost'),
+    condition: () => window.location.hostname.endsWith('hlx.page')
+      || window.location.hostname === 'localhost',
     loadLazy: async () => {
       const preview = await import('../tools/preview/preview.js');
       preview.default();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -9,12 +9,38 @@ import {
   decorateBlocks,
   decorateTemplateAndTheme,
   getMetadata,
+  toClassName,
   waitForLCP,
   loadBlocks,
   loadCSS,
 } from './lib-franklin.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
+
+const audiences = {
+  mobile: () => window.innerWidth < 600,
+  desktop: () => window.innerWidth >= 600,
+  customer: () => document.cookie.split('; ')
+    .find((entry) => entry.startsWith('is-customer='))
+    ?.split('=')[1] || false,
+};
+
+/**
+ * Gets all the metadata elements that are in the given scope.
+ * @param {String} scope The scope/prefix for the metadata
+ * @returns an array of HTMLElement nodes that match the given scope
+ */
+export function getAllMetadata(scope) {
+  return [...document.head.querySelectorAll(`meta[property^="${scope}:"],meta[name^="${scope}-"]`)]
+    .reduce((res, meta) => {
+      const id = toClassName(meta.name
+        ? meta.name.substring(scope.length + 1)
+        : meta.getAttribute('property').split(':')[1]);
+      res[id] = meta.getAttribute('content');
+      return res;
+    }, {});
+}
+
 const plugins = {
   preview: {
     condition: () => window.location.hostname.endsWith('hlx.page') || window.location.hostname === ('localhost'),
@@ -24,17 +50,18 @@ const plugins = {
     },
   },
   experienceDecisioning: {
-    condition: () => getMetadata('experiment') || getMetadata('instant-experiment'),
+    condition: () => getMetadata('experiment')
+      || Object.keys(getAllMetadata('audience')).length,
     loadEager: async () => {
       // eslint-disable-next-line import/no-cycle
       const { loadEager: runEager } = await import('./experience-decisioning/index.js');
-      await runEager();
+      await runEager({ audiences });
     },
     loadLazy: async () => {
       if (window.location.hostname.endsWith('hlx.page') || window.location.hostname === ('localhost')) {
         // eslint-disable-next-line import/extensions
         const { loadLazy: runLazy } = await import('./experience-decisioning/index.js');
-        await runLazy();
+        await runLazy({ audiences });
       }
     },
   },


### PR DESCRIPTION
# Use case

As a marketer, I want to be able to serve different content to different audiences and be able to define those audiences for my project.

# Authoring

This PR adds support for creating page variations for different audiences.

Metadata entries are added to the main entry page for each audience we want to support. The format is as given below:

Audiences can be configured in several ways:
1. directly at the metadata level to serve different content to different audiences:
    <img width="637" alt="Screenshot 2023-08-14 at 10 45 26 AM" src="https://github.com/ramboz/franklin-experience-decisioning/assets/1235810/67032eff-aeaf-438b-82cf-79629fcdf9db">
2.  as an additional filter for an experiment:
    <img width="647" alt="Screenshot 2023-08-14 at 10 46 23 AM" src="https://github.com/ramboz/franklin-experience-decisioning/assets/1235810/63da7da4-920e-4285-acf4-773c4f5ea65b">

Alternative notations like `Audience: Tablet` or `Audience Phablet` are also supported.

When audiences are defined for a page, you can simulate a specific audience by using the `audience` campaign query parameter as shown in the test URLs at the bottom.

At the code level, we also define how to resolve those audiences with simple boolean functions (that can be async):
![Screenshot 2023-08-14 at 10 51 09 AM](https://github.com/ramboz/franklin-experience-decisioning/assets/1235810/a14eda66-d508-4739-93cb-8f98e439945b)

For backward compatibility with the `manifest.xslx` approach we also map the old `audience` property, and added support for the `audiences` one as well.

Test URLs:
- Before: https://main--franklin-experience-decisioning--ramboz.hlx.page/
- After:
  - https://audiences--franklin-experience-decisioning--ramboz.hlx.page/audiences/
  - https://audiences--franklin-experience-decisioning--ramboz.hlx.page/audiences/?audience=mobile
  - https://audiences--franklin-experience-decisioning--ramboz.hlx.page/experiments/control
